### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,23 +9,22 @@
     "url": "https://github.com/AtomLinter/linter-lintr"
   },
   "dependencies": {
-    "atom-linter": "^4.1.1",
+    "atom-linter": "^4.7.0",
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
-    "babel-eslint": "^6.0.2",
-    "coffeelint": "^1.14.1",
-    "eslint": "^2.2.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "coffeelint": "^1.15.2",
+    "eslint": "^2.8.0",
+    "eslint-config-airbnb-base": "^1.0.2",
+    "eslint-plugin-import": "^1.5.0"
   },
   "package-deps": [
     "linter",
     "language-r"
   ],
   "scripts": {
-    "lint": "./node_modules/.bin/coffeelint lib"
+    "test": "apm test",
+    "lint": "coffeelint lib && eslint spec"
   },
   "providedServices": {
     "linter": {
@@ -35,8 +34,7 @@
     }
   },
   "eslintConfig": {
-    "extends": "airbnb/base",
-    "parser": "babel-eslint",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,8 +1,6 @@
 {
-  "globals": {
-    "waitsForPromise": true
-  },
   "env": {
-    "jasmine": true
+    "jasmine": true,
+    "atomtest": true
   }
 }


### PR DESCRIPTION
This package has no need for the React components of eslint-config-airbnb, and doesn't need babel-eslint to be parsed.

Closes #33.
Closes #36.