### PR TITLE
vanilla

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,7 +26,7 @@ module.exports =
         fileText = textEditor.getText() + '\n'
         fileText += '\n' if fileText.slice(-1) isnt '\n'
         return helpers.tempFile path.basename(filePath), fileText, (tmpFilename) ->
-          parameters = ['--slave', '--no-restore', '--no-save', '-e']
+          parameters = ['--vanilla', '--slave', '--no-restore', '--no-save', '-e']
 
           linters = atom.config.get('linter-lintr.linters')
           parameters.push("suppressPackageStartupMessages(library(lintr));lint(commandArgs(TRUE), #{linters})",


### PR DESCRIPTION
R showed the version information of the installed Bioconductor on startup. The linter then showed an error. This resolved this error for me.

----

This is a remake of #62, with the lint issue fixed. According to [the documentation](https://cran.r-project.org/doc/manuals/r-release/R-intro.html#Invoking-R-from-the-command-line) this option specifies several options to clean up the console for running scripts.