### PR TITLE
Ignore the exit code

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -52,8 +52,11 @@ export default {
             `suppressPackageStartupMessages(library(lintr));lint(commandArgs(TRUE), ${linters})`,
             '--args', tmpFilename,
           ];
-
-          return helpers.exec(executablePath, parameters, { stream: 'stdout' }).then((result) => {
+          const execOpts = {
+            stream: 'stdout',
+            ignoreExitCode: true,
+          };
+          return helpers.exec(executablePath, parameters, execOpts).then((result) => {
             if (textEditor.getText() !== fileText) {
               // Editor contents have changed, tell Linter not to update
               return null;


### PR DESCRIPTION
Apparently R can exit with a non-zero exit code when running `lintr`.

Fixes #90.