### PR TITLE
Uniquely spawn processes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -55,10 +55,16 @@ export default {
           const execOpts = {
             stream: 'stdout',
             ignoreExitCode: true,
+            timeout: Infinity,
+            uniqueKey: `linter-lintr::${filePath}`,
           };
           return helpers.exec(executablePath, parameters, execOpts).then((result) => {
             if (textEditor.getText() !== fileText) {
               // Editor contents have changed, tell Linter not to update
+              return null;
+            }
+            if (result === null) {
+              // A newer invocation has been initiated, tell Linter not to update
               return null;
             }
             const toReturn = [];


### PR DESCRIPTION
Disable the execution timeout and handle uniquely spawning the processes so it can run for as long as needed, or until a newer run is requested.

Fixes #90.