### PR TITLE
Defer package dependency loading

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,12 +3,29 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable } from 'atom';
 
-const path = require('path');
-const helpers = require('atom-linter');
+let path;
+let helpers;
+
+function loadDeps() {
+  if (!helpers) {
+    helpers = require('atom-linter');
+  }
+  if (!path) {
+    path = require('path');
+  }
+}
 
 export default {
   activate() {
-    require('atom-package-deps').install('linter-lintr');
+    this.idleCallbacks = new Set();
+    let depCallbackID;
+    const installLinterLintrDeps = () => {
+      this.idleCallbacks.delete(depCallbackID);
+      require('atom-package-deps').install('linter-lintr');
+      loadDeps();
+    };
+    depCallbackID = window.requestIdleCallback(installLinterLintrDeps);
+    this.idleCallbacks.add(depCallbackID);
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-lintr.executablePath', (value) => {
@@ -20,6 +37,8 @@ export default {
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    this.idleCallbacks.clear();
     this.subscriptions.dispose();
   },
 
@@ -30,6 +49,7 @@ export default {
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {
+        loadDeps();
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
         let lintText = fileText;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "atom-linter": "^10.0.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.5.0"
   },
   "devDependencies": {
     "eslint": "^3.16.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   }
 }


### PR DESCRIPTION
Move checking for package dependencies to an idle callback, allowing Atom to take care of that work when it isn't busy with other things. Also moves loading of direct dependencies to opportunistically in the same
idle callback, but on demand in the `lint()` call if it hasn't occurred yet.