### PR TITLE
Specify minimum Atom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
       "description": "which linters to use on the code"
     }
   },
+  "engines": {
+    "atom": ">=1.7.0 <2.0.0"
+  },
   "dependencies": {
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.5.0"


### PR DESCRIPTION
Specifies the mimimum Atom version to be v1.7.0 for
`requestIdleCallback` support, as well as the maximum Atom version to be "below v2".

Fixes #96.