### PR TITLE
Update Travis-CI image to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ git:
 
 sudo: false
 
+dist: trusty
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Atom beta builds on Travis-CI now require their Trusty based image to
build properly.