### PR TITLE
Change to atom-language-r

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "package-deps": [
     "linter:2.0.0",
-    "language-r"
+    "atom-language-r"
   ],
   "scripts": {
     "test": "apm test",


### PR DESCRIPTION
The previously recommended language package is not being maintained, switch to the currently maintained [`atom-language-r`](https://atom.io/packages/atom-language-r).

Fixes #105.