### PR TITLE
Enable .Renviron to set library path

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -57,7 +57,8 @@ export default {
           lintText += '\n';
         }
         const parameters = [
-          '--vanilla', '--slave',
+          '--no-save', '--no-restore', '--no-site-file', '--no-init-file',
+          '--slave',
           '-e',
           `suppressPackageStartupMessages(library(lintr));lint(commandArgs(TRUE), ${this.linters})`,
           '--args',


### PR DESCRIPTION
The current version of linter-lintr requires lintr package to be installed in the system library because R is invoked with `--vanilla`. I would suggest allowing users to use `~/.Renviron` for setting `R_LIBS_USER` to install lintr. This PR replaces `--vanilla` with explicit `--no-*` flags other than `--no-environ`.